### PR TITLE
Some minor corrections

### DIFF
--- a/exercises_1/main.md
+++ b/exercises_1/main.md
@@ -32,7 +32,7 @@ meaning that
 - $\alpha.P$ is the process that can send (or receive) along $\alpha$ and then continue as $P$,
 - $P + Q$ is a process that can act as $P$ (exclusive) or as $Q$,
 - $P | Q$ is the process that results from setting in parallel $P$ and $Q$,
-- $P[\alpha/\beta]$ is the process that results from replacing every occurrence of $\alpha$ by $\beta$ in $P$,
+- $P[\alpha/\beta]$ is the process that results from replacing every occurrence of $\beta$ by $\alpha$ in $P$,
 - $P \backslash \lambda$ is the process $P$ where the channel $\lambda$ is kept private (that is, it can use it only to exchange messages internally),
 - $A \overset{\underset{\mathrm{def}}{}}{=} P$  uses the identifier $A$ to refer to the process $P$ (which may contain the identifier $A$).
 
@@ -41,19 +41,19 @@ This recursive definition, along with replication and recursion, is one of the m
 Exemples:
 ~ Here are some high-level examples:
     
-    - A process $\overline{a} . b.0$ could represent a system that expect a message on port $a$, send a message on port $b$, and then terminate.
+    - A process $\overline{a} . b.0$ could represent a system that expects a message on port $a$, sends a message on port $b$, and then terminates.
     If the message is transferred without being changed, this process represents a forwarder.
-    - A process $(\overline{a} . a . 0) | b.0$ could represent a server that expects a ssh connexion on port $a$ (if the connexion is successful, it would send a message on port $a$) and _in parallel_ wait for printing instructions on port $b$.
+    - A process $(\overline{a} . a . 0) | b.0$ could represent a server that expects a ssh connexion on port $a$ (if the connexion is successful, it would send a message on port $a$) and _in parallel_ waits for printing instructions on port $b$.
     This means that the server can do both actions _at the same time_, and in any order: it could first receive the ssh connexion, then receive printing instructions, and finally send the success message.
     - A process $\overline{a} . 0 + \overline{b}.0$ could represent access to a shared document: a user could log-in on $a$ to edit the document only provided nobody logged-in on $b$, and reciprocally. 
     The process can accept a connexion on $a$ or on $b$, but cannot accept both.
-    - A process $((\overline{a}.0 | a.P) | a.Q) \backslash a$ represent a situation where either $a.P$ or $a.Q$ could send a message to $\overline{a}$ and synchronize with it, but nobody else could, as the channel name $a$ is restricted.
-    - A process $A \overset{\underset{\mathrm{def}}{}}{=} \overline{a} . b . A$ could represent an infinite forwarder: it receives a message on $a$, send it back on $b$, and then wait for a message on $a$ to forward on $b$ again and again.
+    - A process $((\overline{a}.0 | a.P) | a.Q) \backslash a$ represents a situation where either $a.P$ or $a.Q$ could send a message to $\overline{a}$ and synchronize with it, but nobody else could, as the channel name $a$ is restricted.
+    - A process $A \overset{\underset{\mathrm{def}}{}}{=} \overline{a} . b . A$ could represent an infinite forwarder: it receives a message on $a$, sends it back on $b$, and then waits for a message on $a$ to forward on $b$ again and again.
 
 Exercise:
-~ Write a high-level explanation of the situation represented by the process $$((a.P_1.\overline{b}.P_2 | b.Q_1.Q_2) \backslash b) + ((a.Q_1.\overline{c}.Q_2 | c.P_1.P_2) \backslash c)$$ taking inspiration from the following questions:
+~ Write a high-level explanation of the situation represented by the process $$((a.P_1.\overline{b}.P_2 | b.Q_1.Q_2) \backslash b) + ((a.Q_1.\overline{c}.Q_2 | c.P_1.P_2) \backslash c),$$ where $b$ and $c$ do not occur free in $P_1$ and $Q_1$ respectively, taking inspiration from the following questions:
 
-    - Can $b.Q_1.Q_2$ receive a message on $b$ from any other process than $a.P_1.\overline{b}.P_2$?
+    - Can $b.Q_1.Q_2$ send a message through $b$ to any other process than $a.P_1.\overline{b}.P_2$?
     - Can $P_1$ and $Q_1$ execute at the same time?
     - Can $P_2$ and $Q_1$ execute at the same time?
     - Can $Q_1$ execute twice?
@@ -63,7 +63,7 @@ Exercise:
 
     > We assume that the operators have decreasing binding power, in the following order: $\backslash \alpha, \alpha., |, +$.
     
-    Explain the meaning of this (slightly modified) quote, and write down the parenthesised version of a couple of terms without parenthesises.
+    Explain the meaning of this (slightly modified) quote, and write down the parenthesised version of a couple of terms without parentheses.
     For instance, is $a + b | c$ the same as $(a + b) | c$, or the same as $a + (b | c)$? Is $A + a . a | b + c$ the same as $A + ((a.a)|(b+c))$, or is it something else entirely?
 
 
@@ -73,14 +73,14 @@ The processes are then given a _semantics_ (a way of _reducing_, of being execut
 
 ![LTS for CCS\label{fig:semantics}](img/semantics.png)
 
-This means that to decide, for instance, if $a.P + Q \backslash b$ can become $P$, we have to find a _derivation_ using those rules.
+This means that to decide, for instance, if $(a.P + Q) \backslash b$ can become $P$, we have to find a _derivation_ using those rules.
 In this case, we can (almost!) construct it:
 
 - $a.P$ can use the act.\ rule to become $P$,
 - as a consequence, $a.P + Q$ can use the $+_{\text{L}}$ rule to become $P$,
-- as a consequence, and since $b \notin \{a, \overline{a}\}$,  $a.P + Q \backslash b$ (which is the same as $(a.P + Q)\backslash b$) can use the res.\ rule to become … $P \backslash b$.
+- as a consequence, and since $b \notin \{a, \overline{a}\}$,  $(a.P + Q) \backslash b$ can use the res.\ rule to become … $P \backslash b$.
 
-Summarizing, $a.P + Q \backslash b \xrightarrow{a} P \backslash b$, which means that $a.P + Q \backslash b$ can become $P \backslash b$ once it received a message on $a$.
+Summarizing, $(a.P + Q) \backslash b \xrightarrow{a} P \backslash b$, which means that $(a.P + Q) \backslash b$ can become $P \backslash b$ once it received a message on $a$.
 Note that if we had $a = b$, then the process $a.P$ would be stuck: to make progress, it would have te receive a message on $a$ "from the outside world", but this is not possible because of the restriction: this is what the side condition in the res.\ rule guarantee.
 
 Exemples:
@@ -90,7 +90,7 @@ Exemples:
 	- Perform $\overline{a}$, then $a$,
 	- Perform $\tau$, which corresponds to a synchronization.
 
-	In short, it means that the process $a | \overline{a}$ can either communicate with the outside world, or "keep it between then".
+	In short, it means that the process $a | \overline{a}$ can either communicate with the outside world, or "keep it between them".
 	Note that the process $(a | \overline{a}) \backslash a$ can only perform the $\tau$ transition.
 
 

--- a/exercises_3/main.md
+++ b/exercises_3/main.md
@@ -4,11 +4,11 @@ title: "Exercises - 3"
 
 # Forward-Only CCS
 
-A binary relation $\mathcal{R}$ on CCS processes is a _simulation_ if for all $P$, $Q$ such that $P \mathcal{R} Q$^[Which is a notation for "$P$ and $Q$ are in the relationship $\mathcal{R}$", or "$(P, Q) \in \mathcal{R}$".] and for every $\alpha$, $P'$ such that $P \to^{\alpha} P'$, there exists $Q'$ such that  $Q \to^{\alpha} Q'$.
-It is a _bisimulation_ if furthermore for every $\alpha$, $Q'$ such that $Q \to^{\alpha} Q'$, there exists $P'$ such that  $P \to^{\alpha} P'$.
+A binary relation $\mathcal{R}$ on CCS processes is a _simulation_ if for all $P$, $Q$ such that $P \mathcal{R} Q$^[Which is a notation for "$P$ and $Q$ are in the relationship $\mathcal{R}$", or "$(P, Q) \in \mathcal{R}$".] and for every $\alpha$, $P'$ such that $P \to^{\alpha} P'$, there exists $Q'$ such that  $Q \to^{\alpha} Q'$ and $P' \mathcal{R} Q'$.
+It is a _bisimulation_ if furthermore for every $\alpha$, $Q'$ such that $Q \to^{\alpha} Q'$, there exists $P'$ such that  $P \to^{\alpha} P'$ and $P' \mathcal{R} Q'$.
 
 Please not that the $\alpha$ on the label of the transitions _needs to be the same_: intuitively, this means "if $P$ can do $\alpha$, then $Q$ also can do it, and they are still in this relation".
-The *bi*simulation part of the definition stress that we should not worry about "who is leading the game", i.e. if it is $Q$ that should match what $P$ is doing, or the opposite.
+The *bi*simulation part of the definition stresses that we should not worry about "who is leading the game", i.e. if it is $Q$ that should match what $P$ is doing, or the opposite.
 
 #. Prove that the empty relation is a bisimulation.
 #. Prove that the identity relation $\textrm{id}$ ($P \textrm{id} P$ for all $P$) is a bisimulation.
@@ -16,7 +16,7 @@ The *bi*simulation part of the definition stress that we should not worry about 
 #. Prove that any bisimulation $\mathcal{R}$ will be such that $(P \mid Q) \mathcal{R} R$ iff $(Q \mid P) \mathcal{R} R$.^[And once you proved it, wonder if that contradicts the fact that you just proved that the identity was a bisimulation.]
 -->
 
-One generally write that "$P$ and $Q$ _are_ bisimilar" if there exists a bisimulation $\mathcal{R}$ such that $P \mathcal{R} Q$.
+One generally writes that "$P$ and $Q$ _are_ bisimilar" if there exists a bisimulation $\mathcal{R}$ such that $P \mathcal{R} Q$.
 
 #. Prove that $a | a$ and $a.a$ are bisimilar.
 #. Prove that $b | a$ and $a.b$ are _not_ bisimilar.
@@ -27,7 +27,7 @@ One generally write that "$P$ and $Q$ _are_ bisimilar" if there exists a bisimul
 #. Prove that for any $P$, $P + 0$  and $P$ are bisimilar.
 
 The following is inspired from [this sheet](http://didattica.cs.unicam.it/old/lib/exe/fetch.php?media=didattica:magistrale:rtpsv:ay_1617:ex_and_solutions_bisim_hml_weak_fixpoint.pdf).
-For each of the following process decide whether they are bisimilar and if not, justify why not:
+For each of the following processes decide whether they are bisimilar and, if not, justify why not:
 
 #. $b.a + b$ and $b.(a + b)$
 #. $a.(b.c + b.d )$ and $a.b.c + a.b.d$
@@ -43,7 +43,7 @@ Writing $⇝$ the backward transition, a "forward-reverse simulation" [@Lanese2
 - for all $X'$, $\alpha$, $m$ if $X \to^{\alpha[m]} X'$, then there exists $Y'$ such that $Y \to^{\alpha[m]} Y'$ and $X' \mathcal{R} Y'$,
 - for all $X'$, $\alpha$, $m$ if $X ⇝^{\alpha[m]} X'$, then there exists $Y'$ such that $Y ⇝^{\alpha[m]} Y'$ and $X' \mathcal{R} Y'$.
 
-From there, the forward-reverse _bi_simulation is defined as usual.
+From there, the forward-reverse *bi*simulation is defined as usual.
 
 We similarly write that $X$ and $Y$ _are_ bisimilar if there exists a forward-reverse bisimulation between them.
 
@@ -57,7 +57,7 @@ We similarly write that $X$ and $Y$ _are_ bisimilar if there exists a forward-re
 # Discussion
 
 Observe that forcing both terms to have _exactly_ the same keys is not really meaningful: it seems strange to decide that $a[k] | \bar{a}[k]$ and $a[k'] | \bar{a}[k']$, for $k \neq k'$, are not bisimilar.
-Two different solutions to that issues have been explored:
+Two different solutions to that issue have been explored:
 
 - One can either add a rule to rename "bound" keys, e.g. keys that occur in complementary names [@Lanese2021], so that $a[k] | \bar{a}[k]$ and $a[k'] | \bar{a}[k']$ would be considered to be "the same term" (up to renaming, of course),
 - One can change the definition of bisimulation for reversible calculus, so that only a bijection (and not the identity) between the keys is needed [@Aubert2020b].


### PR DESCRIPTION
Modifications made:
- Some grammar corrections
- I didn't modify the input/output convention (it seems like yours is correct, while in the $\pi$-calculus the opposite is usually adopted). I just adjusted the text of the first exercise according to the convention
- I applied your suggested update to the first exercise of the Ex.1 sheet
- In Ex.1, I put some parentheses in (a.P + Q)\b so that your reasoning is correct
- in Ex.3, corrected the definition of bisimulation

Some possible improvements (not applied in this pull request)
- *(probably the most important)* I think the $+_L$ rule in the LTS semantics of CCS (in Ex.1) is wrong: you should have P+Q in the conclusions, instead of Q+P. I can't modify it because it's an image
- You should probably take a decision about your desired interpretation of the "little.collect.collect" issue and correct the exercise accordingly (also observe that, in your last email, you didn't put any parenthesis)
- In Ex.1, in the exercise "list all the different reductions that c.(\overline{a} | (b. a | d )) can perform to reach 0 | (0 | 0)": the exercise is good, because there are sequences, parallel composition and synchronization. However, asking to list *all* of the transitions (which are quite a few) might be too much, for someone who has never seen such transitions.
- In Ex.1, you might add something easy to deal with relabeling (only if you consider this construct important enough): for example, write the derivation tree of $(b.P)[a/b] \xrightarrow{a} P$
- In Ex.2, you ask to list all of the forward and backward transitions of some processes (which is a very useful exercise). You might add some easy process which has more than 1 possible backward transition, like a[k].c | b[k']. I suggest this because, after solving this exercise, I wondered "is there always only one backward transition maximum?"